### PR TITLE
OT139-79-Mod-Endpoint-Datos-Publicos-Redes

### DIFF
--- a/routes/organization.js
+++ b/routes/organization.js
@@ -10,6 +10,10 @@ router.get('/1/public', (req, res, next) => {
     address: 'Barrio La Cava',
     welcomeText:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam molestie interdum rutrum. Nulla luctus est eget feugiat condimentum.',
+    social: {
+      facebook: 'https://www.facebook.com/Somos_Mas',
+      instagram: 'https://www.instagram.com/SomosMas',
+    },
   });
 });
 

--- a/routes/organization.js
+++ b/routes/organization.js
@@ -11,8 +11,12 @@ router.get('/1/public', (req, res, next) => {
     welcomeText:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam molestie interdum rutrum. Nulla luctus est eget feugiat condimentum.',
     social: {
-      facebook: 'https://www.facebook.com/Somos_Mas',
-      instagram: 'https://www.instagram.com/SomosMas',
+      facebook: 'https://www.facebook.com/corpsomosmas',
+      twitter: 'https://twitter.com/somosmas',
+      vimeo: 'https://vimeo.com/somosmas',
+      linkedin: 'https://www.linkedin.com/company/somosmas/',
+      flirk: 'https://www.flickr.com/photos/corporacionsomosmas/albums',
+      youTube: 'https://www.youtube.com/user/corposomosmas',
     },
   });
 });


### PR DESCRIPTION
## Se agrega a la respuesta del endpoint de datos publicos ('/1/public'):
- social: {
      facebook: 'https://www.facebook.com/Somos_Mas',
      instagram: 'https://www.instagram.com/SomosMas',
    },